### PR TITLE
added env variable support for the max # of posts to delete

### DIFF
--- a/.github/workflows/scheduled_delete.yml
+++ b/.github/workflows/scheduled_delete.yml
@@ -9,6 +9,7 @@ on:
 env:
   BLUESKY_HANDLE: ${{ vars.BLUESKY_HANDLE }}
   BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}
+  MAX_DELETE_POSTS: ${{ vars.MAX_DELETE_POSTS || '100' }}
 
 jobs:
   check_bluesky_handle:
@@ -54,5 +55,5 @@ jobs:
           BLUESKY_USER: ${{ vars.BLUESKY_HANDLE }}
           BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}
         run:
-            python delete_hellthreads.py ${BLUESKY_USER} --max-posts 10 --before-date $(date --date="yesterday" +"%Y-%m-%d")
+            python delete_hellthreads.py ${BLUESKY_USER} --max-posts ${MAX_DELETE_POSTS} --before-date $(date --date="yesterday" +"%Y-%m-%d")
 


### PR DESCRIPTION
Uses a repo variable to limit the number of posts deleted in a single run and defaults to 100 if not set